### PR TITLE
[feat] MobileResponseLayout 과 NavigationBarLayout 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.idea
 .env.local
 .env.development.local
 .env.test.local

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,22 @@
 import "./index.css";
 import "./App.css";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import NavigationBarLayout from "./layouts/NavigationBarLayout";
+import { TestApp } from "./pages/TestApp";
+import { MobileResponsiveLayout } from "./layouts/MobileResponsiveLayout";
 
 function App() {
-  return <div className="App">hi</div>;
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route element={<MobileResponsiveLayout />}>
+          <Route exact element={<NavigationBarLayout />}>
+            <Route exact path={"/"} element={<TestApp />} />
+          </Route>
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  );
 }
 
 export default App;

--- a/src/components/navbar/NavBar.jsx
+++ b/src/components/navbar/NavBar.jsx
@@ -1,0 +1,12 @@
+export const NavBar = () => {
+  return (
+    <nav
+      id={"NavBar"}
+      className={"w-full h-navBarHeight absolute bottom-0 flex justify-around"}
+    >
+      <div>Home</div>
+      <div>About</div>
+      <div>Contact</div>
+    </nav>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+html {
+    height: 100%;
+}
+
+body {
+    height: 100%;
+}
+
+#root {
+    height: 100%;
+}

--- a/src/layouts/MobileResponsiveLayout.js
+++ b/src/layouts/MobileResponsiveLayout.js
@@ -1,0 +1,12 @@
+import { Outlet } from "react-router-dom";
+
+export const MobileResponsiveLayout = (props) => {
+  return (
+    <div
+      id={"MobileResponsiveLayout"}
+      className={"relative h-full mx-auto min-w-minWidth max-w-maxWidth"}
+    >
+      <Outlet />
+    </div>
+  );
+};

--- a/src/layouts/NavigationBarLayout.jsx
+++ b/src/layouts/NavigationBarLayout.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Outlet } from "react-router-dom";
+import { NavBar } from "../components/navbar/NavBar";
+
+function NavigationBarLayout(props) {
+  return (
+    <div id={"NavigationBarLayout"} className={"pb-navBarHeight"}>
+      <Outlet />
+      <NavBar />
+    </div>
+  );
+}
+
+export default NavigationBarLayout;

--- a/src/pages/TestApp.jsx
+++ b/src/pages/TestApp.jsx
@@ -1,0 +1,8 @@
+export const TestApp = () => {
+  return (
+    <div>
+      여기는 테스트 컴포넌트 입니다. 나중에 Home의 퍼블리싱이 끝나면 변경될
+      예정입니다.
+    </div>
+  );
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,11 @@ module.exports = {
         sliderBgExercise: "#FF7D7D",
         sliderBgCenter: "#356DD9",
       },
+      spacing: {
+        minWidth: "360px",
+        maxWidth: "1280px",
+        navBarHeight: "90px",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## PR type
- [x] Feature
- [x] Chore

## 💻 작업사항

- MobileResponseLayout 구현
- NavigationBarLayout 구현

## 💡 작성한 이슈 외에 작업한 사항

- tailwindcss.config 에 모바일 최소 px minWidth, 모바일 최대 너비 px maxWidth 설정
- tailwindcss.config 에 navBarHeight 90px 으로 설정
<img width="437" alt="image" src="https://github.com/TUK-DP/frontend-v2/assets/105588857/a1d69ff0-eb39-4282-815c-fa088ff5ab61">


## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
