### PR TITLE
[feat] 일기 디테일 페이지 일기 작성,수정 api 연동하기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-scripts": "5.0.1",
         "react-slick": "^0.30.2",
         "react-spinners": "^0.14.1",
+        "react-textarea-autosize": "^8.5.3",
         "slick-carousel": "^1.8.1",
         "tailwind-scrollbar-hide": "^1.1.7",
         "tailwindcss": "^3.4.4",
@@ -16214,6 +16215,22 @@
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz",
+      "integrity": "sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -18461,6 +18478,43 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-scripts": "5.0.1",
     "react-slick": "^0.30.2",
     "react-spinners": "^0.14.1",
+    "react-textarea-autosize": "^8.5.3",
     "slick-carousel": "^1.8.1",
     "tailwind-scrollbar-hide": "^1.1.7",
     "tailwindcss": "^3.4.4",

--- a/src/apis/diary.controller.js
+++ b/src/apis/diary.controller.js
@@ -9,7 +9,7 @@ import { Api } from "./common.controller";
  *
  *
  * @typedef {{
- *   id : number,
+ *   diaryId : number,
  *   title : string,
  *   createDate : string - YYYY-MM-DD,
  *   content : string,
@@ -48,8 +48,8 @@ class DiaryController extends Api {
     return await this.get("/diary/check", { userId, year, month });
   };
 
-  //일기 작성
   /**
+   * 일기 작성
    * @param userId {number}
    * @param title {string?}
    * @param content {string}
@@ -59,11 +59,33 @@ class DiaryController extends Api {
   createDiary = async ({ userId, title = "쓰레기값", content, date }) => {
     return await this.post("/diary", { userId, title, content, date });
   };
-  // //일기 수정
-  // updateDiary = async (diaryId, diaryData) => {
-  //   return await this.patch(`/diary/${diaryId}`, { data: diaryData });
-  // };
-  // // 일기 삭제
+
+  /**
+   * 일기 수정
+   * @param diaryId {number}
+   * @param userId {number}
+   * @param title {string?}
+   * @param content {string?}
+   * @param date {string?} - YYYY-MM-DD
+   * @return {Promise<AxiosResponse<ApiResponse<Diary>>>}
+   */
+  updateDiary = async ({
+    diaryId,
+    userId,
+    title = "쓰레기값",
+    content,
+    date,
+  }) => {
+    return await this.patch(`/diary/${diaryId}`, {
+      diaryId,
+      userId,
+      title,
+      content,
+      date,
+    });
+  };
+
+  // 일기 삭제
   // deleteDiary = async (diaryId, diaryData) => {
   //   return await this.delete(`/diary/${diaryId}`);
   // };

--- a/src/apis/diary.controller.js
+++ b/src/apis/diary.controller.js
@@ -1,6 +1,4 @@
 import { Api } from "./common.controller";
-import { delay } from "../utils/api/delay";
-import { SECONDS } from "../utils/api/dateConverter";
 
 /**
  * @typedef {{
@@ -50,10 +48,17 @@ class DiaryController extends Api {
     return await this.get("/diary/check", { userId, year, month });
   };
 
-  // //일기 작성
-  // writeDiary = async (diaryData) => {
-  //   return await this.post("/diary", { data: diaryData });
-  // };
+  //일기 작성
+  /**
+   * @param userId {number}
+   * @param title {string?}
+   * @param content {string}
+   * @param date {string} - YYYY-MM-DD
+   * @return {Promise<AxiosResponse<ApiResponse<Diary>>>}
+   */
+  createDiary = async ({ userId, title = "쓰레기값", content, date }) => {
+    return await this.post("/diary", { userId, title, content, date });
+  };
   // //일기 수정
   // updateDiary = async (diaryId, diaryData) => {
   //   return await this.patch(`/diary/${diaryId}`, { data: diaryData });

--- a/src/components/Spinner.jsx
+++ b/src/components/Spinner.jsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { SyncLoader } from "react-spinners";
 
-const Spinner = () => {
-  return <SyncLoader color="#FFFFFF" />;
+const Spinner = ({ color = "#FFFFFF" }) => {
+  return <SyncLoader color={color} />;
 };
 
 export default Spinner;

--- a/src/components/calendar/NoDiary.jsx
+++ b/src/components/calendar/NoDiary.jsx
@@ -1,4 +1,6 @@
 import btn_diary from "../../assets/home/button/btn_diary.png";
+import { DIARY_DETAIL_PAGE_PATH } from "../../pages/diaryDetails/DiaryDetail";
+import { useNavigate } from "react-router-dom";
 
 const NoDiary = ({ isExist }) => {
   if (isExist) {
@@ -19,8 +21,12 @@ const NoDiary = ({ isExist }) => {
 };
 
 const GoWriteDiaryButton = () => {
+  let navigate = useNavigate();
   return (
     <div
+      onClick={() => {
+        navigate(DIARY_DETAIL_PAGE_PATH);
+      }}
       className={
         "flex items-center border-2 rounded-xl h-40 p-4 bg-secondary-600 tablet:h-64 cursor-pointer"
       }

--- a/src/components/diaryDetail/DiaryKeywordImagesSlider.jsx
+++ b/src/components/diaryDetail/DiaryKeywordImagesSlider.jsx
@@ -1,6 +1,7 @@
 import useFetchDiary from "../../hooks/diary/queries/useFetchDiary";
 import Slider from "react-slick";
 import React from "react";
+import useCreateDiary from "../../hooks/diaryDetail/queries/useCreateDiary";
 
 const settings = {
   infinite: false,
@@ -11,8 +12,9 @@ const settings = {
 
 const DiaryKeywordImagesSlider = () => {
   let { isDiaryExist, isCanRender, diary } = useFetchDiary();
+  let { isMutating } = useCreateDiary();
 
-  if (!isDiaryExist || !isCanRender) {
+  if (!isDiaryExist || !isCanRender || isMutating) {
     return null;
   }
 

--- a/src/components/diaryDetail/DiaryKeywordImagesSlider.jsx
+++ b/src/components/diaryDetail/DiaryKeywordImagesSlider.jsx
@@ -2,6 +2,7 @@ import useFetchDiary from "../../hooks/diary/queries/useFetchDiary";
 import Slider from "react-slick";
 import React from "react";
 import useCreateDiary from "../../hooks/diaryDetail/queries/useCreateDiary";
+import useUpdateDiary from "../../hooks/diaryDetail/queries/useUpdateDiary";
 
 const settings = {
   infinite: false,
@@ -12,7 +13,10 @@ const settings = {
 
 const DiaryKeywordImagesSlider = () => {
   let { isDiaryExist, isCanRender, diary } = useFetchDiary();
-  let { isMutating } = useCreateDiary();
+  // console.log(isMutating);
+  const create = useCreateDiary();
+  const update = useUpdateDiary();
+  let isMutating = create.isMutating || update.isMutating;
 
   if (!isDiaryExist || !isCanRender || isMutating) {
     return null;

--- a/src/components/diaryDetail/DiaryKeywordImagesSlider.jsx
+++ b/src/components/diaryDetail/DiaryKeywordImagesSlider.jsx
@@ -1,0 +1,52 @@
+import useFetchDiary from "../../hooks/diary/queries/useFetchDiary";
+import Slider from "react-slick";
+import React from "react";
+
+const settings = {
+  infinite: false,
+  arrows: false,
+  dots: true,
+  swipe: true,
+};
+
+const DiaryKeywordImagesSlider = () => {
+  let { isDiaryExist, diary } = useFetchDiary();
+
+  if (!isDiaryExist) {
+    return null;
+  }
+
+  const keywords = diary.data.result[0].keywords;
+
+  if (!keywords.some(({ imgUrl }) => imgUrl)) {
+    return <NoDiaryImage />;
+  }
+
+  return (
+    <Slider {...settings} className={"w-full rounded-xl overflow-clip"}>
+      {keywords.map(({ keywordId, imgUrl, keyword }, index) => (
+        <img
+          key={keywordId}
+          src={imgUrl}
+          alt={keyword}
+          className={`w-full bg-white aspect-square`}
+        />
+      ))}
+    </Slider>
+  );
+};
+
+export default DiaryKeywordImagesSlider;
+
+const NoDiaryImage = () => {
+  return (
+    <div className={"mx-auto font-bold h-auto"}>
+      <span className={"text-2xl text-end tablet:text-4xl text-nowrap"}>
+        그려진 그림이 없어요.. <span className={"ml-4"}>😢</span>
+      </span>
+      <p className={"text-xl text-end mt-6 tablet:text-3xl cursor-pointer"}>
+        그림 그리러 가기 >
+      </p>
+    </div>
+  );
+};

--- a/src/components/diaryDetail/DiaryKeywordImagesSlider.jsx
+++ b/src/components/diaryDetail/DiaryKeywordImagesSlider.jsx
@@ -10,13 +10,13 @@ const settings = {
 };
 
 const DiaryKeywordImagesSlider = () => {
-  let { isDiaryExist, diary } = useFetchDiary();
+  let { isDiaryExist, isCanRender, diary } = useFetchDiary();
 
-  if (!isDiaryExist) {
+  if (!isDiaryExist || !isCanRender) {
     return null;
   }
 
-  const keywords = diary.data.result[0].keywords;
+  const keywords = diary.keywords;
 
   if (!keywords.some(({ imgUrl }) => imgUrl)) {
     return <NoDiaryImage />;

--- a/src/hooks/diary/queries/useFetchDiary.js
+++ b/src/hooks/diary/queries/useFetchDiary.js
@@ -33,7 +33,8 @@ const useFetchDiary = () => {
 };
 
 export const diaryQueryKey = (selectedDate) => {
-  return ["diary", selectedDate];
+  const { year, month, day } = selectedDate;
+  return ["diary", year, month, day];
 };
 
 export default useFetchDiary;

--- a/src/hooks/diary/queries/useFetchDiaryChecks.js
+++ b/src/hooks/diary/queries/useFetchDiaryChecks.js
@@ -49,7 +49,8 @@ const useFetchDiaryChecks = () => {
 };
 
 export const diaryCheckQueryKey = (selectedYearMonth) => {
-  return ["diary", "check", selectedYearMonth];
+  const { year, month } = selectedYearMonth;
+  return ["diary", year, month];
 };
 
 export default useFetchDiaryChecks;

--- a/src/hooks/diaryDetail/queries/useCreateDiary.js
+++ b/src/hooks/diaryDetail/queries/useCreateDiary.js
@@ -1,0 +1,71 @@
+import {
+  useIsMutating,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { delay } from "../../../utils/api/delay";
+import { diaryCheckQueryKey } from "../../diary/queries/useFetchDiaryChecks";
+import {
+  dateToDashString,
+  yearMonthToDashString,
+} from "../../../utils/api/dateConverter";
+import useFetchDiary, {
+  diaryQueryKey,
+} from "../../diary/queries/useFetchDiary";
+import { useCalendarStore } from "../../../stores/CalendarStore";
+import DiaryController from "../../../apis/diary.controller";
+
+const useCreateDiary = () => {
+  const { selectedDate, selectedYearMonth } = useCalendarStore(
+    (state) => state
+  );
+  let { isDiaryExist } = useFetchDiary();
+
+  let queryClient = useQueryClient();
+
+  const { mutate } = useMutation({
+    mutationKey: ["diary", selectedDate],
+    mutationFn: async (content) => {
+      await delay(6000);
+      return await DiaryController.createDiary({
+        userId: 2,
+        content,
+        date: dateToDashString(selectedDate),
+      });
+    },
+    onMutate: async (content) => {
+      console.log(content);
+      // 일기 저장 전에 일기가 있는지 확인
+      if (isDiaryExist) return;
+
+      queryClient.setQueryData(
+        diaryCheckQueryKey(selectedYearMonth),
+        (old) => ({
+          [yearMonthToDashString(selectedYearMonth)]: {
+            ...old[yearMonthToDashString(selectedYearMonth)],
+            [selectedDate.day]: { isExist: true },
+          },
+        })
+      );
+
+      queryClient.setQueryData(diaryQueryKey(selectedDate), (old) => ({
+        ...old,
+        content,
+        keywords: [],
+      }));
+    },
+    onSuccess: async () => {
+      // 일기 저장 성공시
+      await queryClient.invalidateQueries({
+        queryKey: diaryQueryKey(selectedDate).slice(0, -1),
+      });
+    },
+  });
+
+  const isMutating = useIsMutating({
+    mutationKey: ["diary", selectedDate],
+  });
+
+  return { mutate, isMutating: isMutating === 1 };
+};
+export default useCreateDiary;

--- a/src/hooks/diaryDetail/queries/useCreateDiary.js
+++ b/src/hooks/diaryDetail/queries/useCreateDiary.js
@@ -9,9 +9,7 @@ import {
   dateToDashString,
   yearMonthToDashString,
 } from "../../../utils/api/dateConverter";
-import useFetchDiary, {
-  diaryQueryKey,
-} from "../../diary/queries/useFetchDiary";
+import { diaryQueryKey } from "../../diary/queries/useFetchDiary";
 import { useCalendarStore } from "../../../stores/CalendarStore";
 import DiaryController from "../../../apis/diary.controller";
 
@@ -19,12 +17,11 @@ const useCreateDiary = () => {
   const { selectedDate, selectedYearMonth } = useCalendarStore(
     (state) => state
   );
-  let { isDiaryExist } = useFetchDiary();
 
   let queryClient = useQueryClient();
 
   const { mutate } = useMutation({
-    mutationKey: ["diary", selectedDate],
+    mutationKey: ["diary", "create", selectedDate],
     mutationFn: async (content) => {
       await delay(6000);
       return await DiaryController.createDiary({
@@ -34,10 +31,6 @@ const useCreateDiary = () => {
       });
     },
     onMutate: async (content) => {
-      console.log(content);
-      // 일기 저장 전에 일기가 있는지 확인
-      if (isDiaryExist) return;
-
       queryClient.setQueryData(
         diaryCheckQueryKey(selectedYearMonth),
         (old) => ({
@@ -63,7 +56,7 @@ const useCreateDiary = () => {
   });
 
   const isMutating = useIsMutating({
-    mutationKey: ["diary", selectedDate],
+    mutationKey: ["diary", "create", selectedDate],
   });
 
   return { mutate, isMutating: isMutating === 1 };

--- a/src/hooks/diaryDetail/queries/useCreateDiary.js
+++ b/src/hooks/diaryDetail/queries/useCreateDiary.js
@@ -23,7 +23,6 @@ const useCreateDiary = () => {
   const { mutate } = useMutation({
     mutationKey: ["diary", "create", selectedDate],
     mutationFn: async (content) => {
-      await delay(6000);
       return await DiaryController.createDiary({
         userId: 2,
         content,

--- a/src/hooks/diaryDetail/queries/useUpdateDiary.js
+++ b/src/hooks/diaryDetail/queries/useUpdateDiary.js
@@ -24,7 +24,6 @@ const useUpdateDiary = () => {
   const { mutate } = useMutation({
     mutationKey: ["diary", "update", selectedDate],
     mutationFn: async (content) => {
-      await delay(6000);
       return await DiaryController.updateDiary({
         userId: 2,
         diaryId: diary.diaryId,

--- a/src/hooks/diaryDetail/queries/useUpdateDiary.js
+++ b/src/hooks/diaryDetail/queries/useUpdateDiary.js
@@ -1,0 +1,66 @@
+import { useCalendarStore } from "../../../stores/CalendarStore";
+import {
+  useIsMutating,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { delay } from "../../../utils/api/delay";
+import DiaryController from "../../../apis/diary.controller";
+import { yearMonthToDashString } from "../../../utils/api/dateConverter";
+import { diaryCheckQueryKey } from "../../diary/queries/useFetchDiaryChecks";
+import useFetchDiary, {
+  diaryQueryKey,
+} from "../../diary/queries/useFetchDiary";
+
+const useUpdateDiary = () => {
+  const { selectedDate, selectedYearMonth } = useCalendarStore(
+    (state) => state
+  );
+
+  let queryClient = useQueryClient();
+
+  let { diary } = useFetchDiary();
+
+  const { mutate } = useMutation({
+    mutationKey: ["diary", "update", selectedDate],
+    mutationFn: async (content) => {
+      await delay(6000);
+      return await DiaryController.updateDiary({
+        userId: 2,
+        diaryId: diary.diaryId,
+        content,
+      });
+    },
+    onMutate: async (content) => {
+      queryClient.setQueryData(
+        diaryCheckQueryKey(selectedYearMonth),
+        (old) => ({
+          [yearMonthToDashString(selectedYearMonth)]: {
+            ...old[yearMonthToDashString(selectedYearMonth)],
+            [selectedDate.day]: { isExist: true },
+          },
+        })
+      );
+
+      queryClient.setQueryData(diaryQueryKey(selectedDate), (old) => ({
+        ...old,
+        content,
+        keywords: [],
+      }));
+    },
+    onSuccess: async () => {
+      // 일기 저장 성공시
+      await queryClient.invalidateQueries({
+        queryKey: diaryQueryKey(selectedDate).slice(0, -1),
+      });
+    },
+  });
+
+  const isMutating = useIsMutating({
+    mutationKey: ["diary", "update", selectedDate],
+  });
+
+  return { mutate, isMutating: isMutating === 1 };
+};
+
+export default useUpdateDiary;

--- a/src/hooks/diaryDetail/useDiaryControl.js
+++ b/src/hooks/diaryDetail/useDiaryControl.js
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import useFetchDiary from "../diary/queries/useFetchDiary";
 import { useInput } from "../inputs/useInput";
 
 const useDiaryControl = () => {
   let { isDiaryExist, diary } = useFetchDiary();
+  const textAreaRef = useRef(null);
 
   let { form, handleChangeInput } = useInput({
     content: diary?.content || "",
@@ -16,23 +17,25 @@ const useDiaryControl = () => {
   });
 
   // 저장이나 수정 버튼 클릭 이벤트
-  const handleClick = (whenDiaryAction) => {
+  const handleClick = async (whenDiaryAction) => {
     // 수정하기 버튼 클릭시 수정 완료 버튼으로 변경
     if (!controlState.isEditActive) {
-      setControlState({
+      await setControlState({
         ...controlState,
         isEditActive: true,
         controlButtonText: "수정 완료",
       });
+      textAreaRef.current.focus();
       return;
     }
 
     // 일기 입력한 내용이 없을 때
     if (form.content === "") {
-      setControlState({
+      await setControlState({
         ...controlState,
         controlButtonMessage: "일기를 입력해주세요.",
       });
+      textAreaRef.current.focus();
       return;
     }
 
@@ -53,6 +56,7 @@ const useDiaryControl = () => {
     handleChangeInput,
     controlState,
     handleClick,
+    textAreaRef,
   };
 };
 

--- a/src/hooks/diaryDetail/useDiaryControl.js
+++ b/src/hooks/diaryDetail/useDiaryControl.js
@@ -1,14 +1,9 @@
 import { useState } from "react";
 import useFetchDiary from "../diary/queries/useFetchDiary";
-import { useIsMutating } from "@tanstack/react-query";
-import { useCalendarStore } from "../../stores/CalendarStore";
 import { useInput } from "../inputs/useInput";
 
 const useDiaryControl = () => {
   let { isDiaryExist, diary } = useFetchDiary();
-  const { selectedDate } = useCalendarStore((state) => state);
-
-  const isMutating = useIsMutating({ mutationKey: ["diary", selectedDate] });
 
   let { form, handleChangeInput } = useInput({
     content: diary?.content || "",
@@ -16,9 +11,8 @@ const useDiaryControl = () => {
 
   const [controlState, setControlState] = useState({
     isEditActive: !isDiaryExist,
-    controlButtonActive: true,
     controlButtonText: `${!isDiaryExist ? "작성하기" : "수정하기"}`,
-    controlButtonMessage: isMutating ? "키워드 추출중입니다!" : " ",
+    controlButtonMessage: " ",
   });
 
   // 저장이나 수정 버튼 클릭 이벤트
@@ -46,8 +40,8 @@ const useDiaryControl = () => {
     setControlState({
       ...controlState,
       isEditActive: false,
-      controlButtonActive: false,
-      controlButtonMessage: "키워드 추출중입니다!",
+      controlButtonMessage: " ",
+      controlButtonText: "수정하기",
     });
 
     // 일기 저장 또는 수정 API 호출
@@ -61,5 +55,13 @@ const useDiaryControl = () => {
     handleClick,
   };
 };
+
+/**
+ * @typedef {{
+ *   isEditActive: boolean,
+ *   controlButtonText: string,
+ *   controlButtonMessage: string
+ * }} ControlState
+ */
 
 export default useDiaryControl;

--- a/src/hooks/diaryDetail/useDiaryControl.js
+++ b/src/hooks/diaryDetail/useDiaryControl.js
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import useFetchDiary from "../diary/queries/useFetchDiary";
+import { useIsMutating } from "@tanstack/react-query";
+import { useCalendarStore } from "../../stores/CalendarStore";
+import { useInput } from "../inputs/useInput";
+
+const useDiaryControl = () => {
+  let { isDiaryExist, diary } = useFetchDiary();
+  const { selectedDate } = useCalendarStore((state) => state);
+
+  const isMutating = useIsMutating({ mutationKey: ["diary", selectedDate] });
+
+  let { form, handleChangeInput } = useInput({
+    content: diary?.content || "",
+  });
+
+  const [controlState, setControlState] = useState({
+    isEditActive: !isDiaryExist,
+    controlButtonActive: true,
+    controlButtonText: `${!isDiaryExist ? "작성하기" : "수정하기"}`,
+    controlButtonMessage: isMutating ? "키워드 추출중입니다!" : " ",
+  });
+
+  // 저장이나 수정 버튼 클릭 이벤트
+  const handleClick = (whenDiaryAction) => {
+    // 수정하기 버튼 클릭시 수정 완료 버튼으로 변경
+    if (!controlState.isEditActive) {
+      setControlState({
+        ...controlState,
+        isEditActive: true,
+        controlButtonText: "수정 완료",
+      });
+      return;
+    }
+
+    // 일기 입력한 내용이 없을 때
+    if (form.content === "") {
+      setControlState({
+        ...controlState,
+        controlButtonMessage: "일기를 입력해주세요.",
+      });
+      return;
+    }
+
+    // 일기 내용이 있을 때 일기 저장
+    setControlState({
+      ...controlState,
+      isEditActive: false,
+      controlButtonActive: false,
+      controlButtonMessage: "키워드 추출중입니다!",
+    });
+
+    // 일기 저장 또는 수정 API 호출
+    whenDiaryAction();
+  };
+
+  return {
+    content: form.content,
+    handleChangeInput,
+    controlState,
+    handleClick,
+  };
+};
+
+export default useDiaryControl;

--- a/src/hooks/diaryDetail/useDiaryControl.js
+++ b/src/hooks/diaryDetail/useDiaryControl.js
@@ -11,7 +11,7 @@ const useDiaryControl = () => {
 
   const [controlState, setControlState] = useState({
     isEditActive: !isDiaryExist,
-    controlButtonText: `${!isDiaryExist ? "작성하기" : "수정하기"}`,
+    controlButtonText: `${!isDiaryExist ? "저장" : "수정하기"}`,
     controlButtonMessage: " ",
   });
 

--- a/src/pages/diaryDetails/DiaryControlButton.jsx
+++ b/src/pages/diaryDetails/DiaryControlButton.jsx
@@ -1,0 +1,50 @@
+/**
+ * @param content
+ * @param className
+ * @param controlState {ControlState}
+ * @param setControlState
+ * @param props
+ * @return {Element}
+ */
+const DiaryControlButton = ({
+  content,
+  className,
+  controlState,
+  setControlState,
+  ...props
+}) => {
+  const handleClick = (e) => {
+    if (content === "") {
+      setControlState({
+        ...controlState,
+        message: "일기를 입력해주세요.",
+      });
+      return;
+    }
+
+    setControlState({
+      ...controlState,
+      isEditActive: false,
+      controlButtonActive: false,
+      controlButtonMessage: "",
+    });
+  };
+
+  return (
+    <>
+      <div className={"text-2xl text-red-600 text-center"}>
+        {controlState.controlButtonMessage}
+      </div>
+      <button
+        disabled={!controlState.controlButtonActive}
+        onClick={handleClick}
+        className={`border-2 bg-secondary-400 rounded-lg text-2xl py-3 ${className}`}
+        {...props}
+      >
+        {controlState.controlButtonText}
+      </button>
+    </>
+  );
+};
+
+export default DiaryControlButton;

--- a/src/pages/diaryDetails/DiaryControlButton.jsx
+++ b/src/pages/diaryDetails/DiaryControlButton.jsx
@@ -16,14 +16,14 @@ import Spinner from "../../components/Spinner";
  * @param content {string}
  * @param className {string}
  * @param controlState {ControlState}
- * @param setControlState {React.Dispatch<React.SetStateAction<ControlState>>}
+ * @param handleClick {(whenDiaryAction : () => void) => void}
  * @param props {React.HTMLProps}
  */
 const DiaryControlButton = ({
   content,
   className,
   controlState,
-  setControlState,
+  handleClick,
   ...props
 }) => {
   const { selectedDate, selectedYearMonth } = useCalendarStore(
@@ -73,38 +73,6 @@ const DiaryControlButton = ({
   });
   const isMutating = useIsMutating(["diary", selectedDate]);
 
-  const handleClick = (e) => {
-    // 수정하기 버튼 클릭시 수정 완료 버튼으로 변경
-    if (!controlState.isEditActive) {
-      setControlState({
-        ...controlState,
-        isEditActive: true,
-        controlButtonText: "수정 완료",
-      });
-      return;
-    }
-
-    // 일기 내용이 없을 때
-    if (content === "") {
-      setControlState({
-        ...controlState,
-        controlButtonMessage: "일기를 입력해주세요.",
-      });
-      return;
-    }
-
-    // 일기 내용이 있을 때 일기 저장
-    setControlState({
-      ...controlState,
-      isEditActive: false,
-      controlButtonActive: false,
-      controlButtonMessage: "키워드 추출중입니다!",
-    });
-
-    // 일기 저장 API 호출
-    mutate();
-  };
-
   return (
     <>
       <div
@@ -114,7 +82,7 @@ const DiaryControlButton = ({
       </div>
       <button
         disabled={isMutating || !controlState.controlButtonActive}
-        onClick={handleClick}
+        onClick={() => handleClick(mutate)}
         className={`border-2 bg-secondary-400 rounded-lg text-2xl py-3 ${className}`}
         {...props}
       >

--- a/src/pages/diaryDetails/DiaryControlButton.jsx
+++ b/src/pages/diaryDetails/DiaryControlButton.jsx
@@ -1,22 +1,11 @@
-import {
-  useIsMutating,
-  useMutation,
-  useQueryClient,
-} from "@tanstack/react-query";
-import { useCalendarStore } from "../../stores/CalendarStore";
-import { delay } from "../../utils/api/delay";
-import { diaryCheckQueryKey } from "../../hooks/diary/queries/useFetchDiaryChecks";
-import useFetchDiary, {
-  diaryQueryKey,
-} from "../../hooks/diary/queries/useFetchDiary";
-import { yearMonthToDashString } from "../../utils/api/dateConverter";
 import Spinner from "../../components/Spinner";
+import useCreateDiary from "../../hooks/diaryDetail/queries/useCreateDiary";
 
 /**
  * @param content {string}
  * @param className {string}
  * @param controlState {ControlState}
- * @param handleClick {(whenDiaryAction : () => void) => void}
+ * @param handleClick {(whenDiaryAction : () => any) => void}
  * @param props {React.HTMLProps}
  */
 const DiaryControlButton = ({
@@ -26,71 +15,23 @@ const DiaryControlButton = ({
   handleClick,
   ...props
 }) => {
-  const { selectedDate, selectedYearMonth } = useCalendarStore(
-    (state) => state
-  );
-
-  let { isDiaryExist } = useFetchDiary();
-
-  let queryClient = useQueryClient();
-  const { mutate } = useMutation({
-    mutationKey: ["diary", selectedDate],
-    mutationFn: async () => {
-      await delay(100000);
-      // return await DiaryController.postDiary({
-      //   userId: 2,
-      //   content,
-      //   date: dateToDashString(selectedDate),
-      // })
-    },
-    onMutate: async () => {
-      // 일기 저장 전에 일기가 있는지 확인
-      if (isDiaryExist) return;
-
-      queryClient.setQueryData(
-        diaryCheckQueryKey(selectedYearMonth),
-        (old) => ({
-          [yearMonthToDashString(selectedYearMonth)]: {
-            ...old[yearMonthToDashString(selectedYearMonth)],
-            [selectedDate.day]: { isExist: true },
-          },
-        })
-      );
-
-      queryClient.setQueryData(diaryQueryKey(selectedDate), (old) => ({
-        ...old,
-        content,
-        keywords: [],
-      }));
-    },
-    onSuccess: async () => {
-      // 일기 저장 성공시
-      await queryClient.invalidateQueries(
-        diaryCheckQueryKey(selectedYearMonth)
-      );
-      await queryClient.invalidateQueries(diaryQueryKey(selectedDate));
-    },
-  });
-  const isMutating = useIsMutating(["diary", selectedDate]);
+  let { isMutating, mutate } = useCreateDiary();
 
   return (
     <>
-      <div
-        className={`whitespace-pre text-2xl text-red-600 text-center ${controlState.controlButtonMessage === " " ? "invisible" : "visible"}`}
-      >
-        {controlState.controlButtonMessage}
+      <div className={`whitespace-pre text-2xl text-red-600 text-center`}>
+        {isMutating
+          ? "키워드 추출중입니다!"
+          : controlState.controlButtonMessage}
       </div>
       <button
-        disabled={isMutating || !controlState.controlButtonActive}
-        onClick={() => handleClick(mutate)}
+        disabled={isMutating}
+        onClick={() => handleClick(() => mutate(content))}
         className={`border-2 bg-secondary-400 rounded-lg text-2xl py-3 ${className}`}
         {...props}
       >
-        {isMutating ? (
-          <Spinner color={"black"} />
-        ) : (
-          controlState.controlButtonText
-        )}
+        {isMutating && <Spinner color={"black"} />}
+        {!isMutating && controlState.controlButtonText}
       </button>
     </>
   );

--- a/src/pages/diaryDetails/DiaryControlButton.jsx
+++ b/src/pages/diaryDetails/DiaryControlButton.jsx
@@ -1,5 +1,7 @@
 import Spinner from "../../components/Spinner";
 import useCreateDiary from "../../hooks/diaryDetail/queries/useCreateDiary";
+import useUpdateDiary from "../../hooks/diaryDetail/queries/useUpdateDiary";
+import useFetchDiary from "../../hooks/diary/queries/useFetchDiary";
 
 /**
  * @param content {string}
@@ -15,7 +17,11 @@ const DiaryControlButton = ({
   handleClick,
   ...props
 }) => {
-  let { isMutating, mutate } = useCreateDiary();
+  let { isDiaryExist } = useFetchDiary();
+  const create = useCreateDiary();
+  const update = useUpdateDiary();
+
+  const isMutating = create.isMutating || update.isMutating;
 
   return (
     <>
@@ -26,7 +32,11 @@ const DiaryControlButton = ({
       </div>
       <button
         disabled={isMutating}
-        onClick={() => handleClick(() => mutate(content))}
+        onClick={() =>
+          handleClick(() => {
+            isDiaryExist ? update.mutate(content) : create.mutate(content);
+          })
+        }
         className={`border-2 bg-secondary-400 rounded-lg text-2xl py-3 ${className}`}
         {...props}
       >

--- a/src/pages/diaryDetails/DiaryControlButton.jsx
+++ b/src/pages/diaryDetails/DiaryControlButton.jsx
@@ -1,10 +1,23 @@
+import {
+  useIsMutating,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useCalendarStore } from "../../stores/CalendarStore";
+import { delay } from "../../utils/api/delay";
+import { diaryCheckQueryKey } from "../../hooks/diary/queries/useFetchDiaryChecks";
+import useFetchDiary, {
+  diaryQueryKey,
+} from "../../hooks/diary/queries/useFetchDiary";
+import { yearMonthToDashString } from "../../utils/api/dateConverter";
+import Spinner from "../../components/Spinner";
+
 /**
- * @param content
- * @param className
+ * @param content {string}
+ * @param className {string}
  * @param controlState {ControlState}
- * @param setControlState
- * @param props
- * @return {Element}
+ * @param setControlState {React.Dispatch<React.SetStateAction<ControlState>>}
+ * @param props {React.HTMLProps}
  */
 const DiaryControlButton = ({
   content,
@@ -13,35 +26,103 @@ const DiaryControlButton = ({
   setControlState,
   ...props
 }) => {
+  const { selectedDate, selectedYearMonth } = useCalendarStore(
+    (state) => state
+  );
+
+  let { isDiaryExist } = useFetchDiary();
+
+  let queryClient = useQueryClient();
+  const { mutate } = useMutation({
+    mutationKey: ["diary", selectedDate],
+    mutationFn: async () => {
+      await delay(100000);
+      // return await DiaryController.postDiary({
+      //   userId: 2,
+      //   content,
+      //   date: dateToDashString(selectedDate),
+      // })
+    },
+    onMutate: async () => {
+      // 일기 저장 전에 일기가 있는지 확인
+      if (isDiaryExist) return;
+
+      queryClient.setQueryData(
+        diaryCheckQueryKey(selectedYearMonth),
+        (old) => ({
+          [yearMonthToDashString(selectedYearMonth)]: {
+            ...old[yearMonthToDashString(selectedYearMonth)],
+            [selectedDate.day]: { isExist: true },
+          },
+        })
+      );
+
+      queryClient.setQueryData(diaryQueryKey(selectedDate), (old) => ({
+        ...old,
+        content,
+        keywords: [],
+      }));
+    },
+    onSuccess: async () => {
+      // 일기 저장 성공시
+      await queryClient.invalidateQueries(
+        diaryCheckQueryKey(selectedYearMonth)
+      );
+      await queryClient.invalidateQueries(diaryQueryKey(selectedDate));
+    },
+  });
+  const isMutating = useIsMutating(["diary", selectedDate]);
+
   const handleClick = (e) => {
-    if (content === "") {
+    // 수정하기 버튼 클릭시 수정 완료 버튼으로 변경
+    if (!controlState.isEditActive) {
       setControlState({
         ...controlState,
-        message: "일기를 입력해주세요.",
+        isEditActive: true,
+        controlButtonText: "수정 완료",
       });
       return;
     }
 
+    // 일기 내용이 없을 때
+    if (content === "") {
+      setControlState({
+        ...controlState,
+        controlButtonMessage: "일기를 입력해주세요.",
+      });
+      return;
+    }
+
+    // 일기 내용이 있을 때 일기 저장
     setControlState({
       ...controlState,
       isEditActive: false,
       controlButtonActive: false,
-      controlButtonMessage: "",
+      controlButtonMessage: "키워드 추출중입니다!",
     });
+
+    // 일기 저장 API 호출
+    mutate();
   };
 
   return (
     <>
-      <div className={"text-2xl text-red-600 text-center"}>
+      <div
+        className={`whitespace-pre text-2xl text-red-600 text-center ${controlState.controlButtonMessage === " " ? "invisible" : "visible"}`}
+      >
         {controlState.controlButtonMessage}
       </div>
       <button
-        disabled={!controlState.controlButtonActive}
+        disabled={isMutating || !controlState.controlButtonActive}
         onClick={handleClick}
         className={`border-2 bg-secondary-400 rounded-lg text-2xl py-3 ${className}`}
         {...props}
       >
-        {controlState.controlButtonText}
+        {isMutating ? (
+          <Spinner color={"black"} />
+        ) : (
+          controlState.controlButtonText
+        )}
       </button>
     </>
   );

--- a/src/pages/diaryDetails/DiaryDetail.jsx
+++ b/src/pages/diaryDetails/DiaryDetail.jsx
@@ -5,6 +5,7 @@ import TextareaAutosize from "react-textarea-autosize";
 import DiaryKeywordImagesSlider from "../../components/diaryDetail/DiaryKeywordImagesSlider";
 import DiaryControlButton from "./DiaryControlButton";
 import useDiaryControl from "../../hooks/diaryDetail/useDiaryControl";
+import useCreateDiary from "../../hooks/diaryDetail/queries/useCreateDiary";
 
 export const DIARY_DETAIL_PAGE_PATH = "/diary/detail";
 
@@ -12,13 +13,15 @@ const DiaryDetail = () => {
   let { handleClick, controlState, content, handleChangeInput } =
     useDiaryControl();
 
+  let { isMutating } = useCreateDiary();
+
   return (
     <div className={"flex flex-col gap-10 px-10 pb-10"}>
       <DiaryDate />
       <DiaryKeywordImagesSlider />
       <TextareaAutosize
         value={content}
-        disabled={!controlState.isEditActive}
+        disabled={isMutating || !controlState.isEditActive}
         className={
           "bg-transparent resize-none overflow-hidden text-3xl outline-none whitespace-pre-wrap"
         }
@@ -51,12 +54,3 @@ const DiaryDate = () => {
 };
 
 export default DiaryDetail;
-
-/**
- * @typedef {{
- *   isEditActive: boolean,
- *   controlButtonActive: boolean,
- *   controlButtonText: string,
- *   controlButtonMessage: string
- * }} ControlState
- */

--- a/src/pages/diaryDetails/DiaryDetail.jsx
+++ b/src/pages/diaryDetails/DiaryDetail.jsx
@@ -6,6 +6,7 @@ import DiaryKeywordImagesSlider from "../../components/diaryDetail/DiaryKeywordI
 import DiaryControlButton from "./DiaryControlButton";
 import useDiaryControl from "../../hooks/diaryDetail/useDiaryControl";
 import useCreateDiary from "../../hooks/diaryDetail/queries/useCreateDiary";
+import useUpdateDiary from "../../hooks/diaryDetail/queries/useUpdateDiary";
 
 export const DIARY_DETAIL_PAGE_PATH = "/diary/detail";
 
@@ -13,7 +14,9 @@ const DiaryDetail = () => {
   let { handleClick, controlState, content, handleChangeInput } =
     useDiaryControl();
 
-  let { isMutating } = useCreateDiary();
+  const create = useCreateDiary();
+  const update = useUpdateDiary();
+  let isMutating = create.isMutating || update.isMutating;
 
   return (
     <div className={"flex flex-col gap-10 px-10 pb-10"}>

--- a/src/pages/diaryDetails/DiaryDetail.jsx
+++ b/src/pages/diaryDetails/DiaryDetail.jsx
@@ -1,39 +1,23 @@
-import React, { useState } from "react";
+import React from "react";
 import { dateToDotString } from "../../utils/api/dateConverter";
 import { useCalendarStore } from "../../stores/CalendarStore";
-import useFetchDiary from "../../hooks/diary/queries/useFetchDiary";
-import { useInput } from "../../hooks/inputs/useInput";
 import TextareaAutosize from "react-textarea-autosize";
 import DiaryKeywordImagesSlider from "../../components/diaryDetail/DiaryKeywordImagesSlider";
 import DiaryControlButton from "./DiaryControlButton";
-import { useIsMutating } from "@tanstack/react-query";
+import useDiaryControl from "../../hooks/diaryDetail/useDiaryControl";
 
 export const DIARY_DETAIL_PAGE_PATH = "/diary/detail";
 
 const DiaryDetail = () => {
-  let { diary, isDiaryExist } = useFetchDiary();
-  const content = diary?.content;
-
-  let { form, handleChangeInput } = useInput({
-    content: content || "",
-  });
-  const { selectedDate } = useCalendarStore((state) => state);
-
-  const isMutating = useIsMutating({ mutationKey: ["diary", selectedDate] });
-
-  const [controlState, setControlState] = useState({
-    isEditActive: !isDiaryExist,
-    controlButtonActive: true,
-    controlButtonText: `${!isDiaryExist ? "작성하기" : "수정하기"}`,
-    controlButtonMessage: isMutating ? "키워드 추출중입니다!" : " ",
-  });
+  let { handleClick, controlState, content, handleChangeInput } =
+    useDiaryControl();
 
   return (
     <div className={"flex flex-col gap-10 px-10 pb-10"}>
       <DiaryDate />
       <DiaryKeywordImagesSlider />
       <TextareaAutosize
-        value={form.content}
+        value={content}
         disabled={!controlState.isEditActive}
         className={
           "bg-transparent resize-none overflow-hidden text-3xl outline-none whitespace-pre-wrap"
@@ -43,9 +27,9 @@ const DiaryDetail = () => {
         onChange={handleChangeInput}
       />
       <DiaryControlButton
-        content={form.content}
+        content={content}
         controlState={controlState}
-        setControlState={setControlState}
+        handleClick={handleClick}
       />
     </div>
   );

--- a/src/pages/diaryDetails/DiaryDetail.jsx
+++ b/src/pages/diaryDetails/DiaryDetail.jsx
@@ -6,22 +6,26 @@ import { useInput } from "../../hooks/inputs/useInput";
 import TextareaAutosize from "react-textarea-autosize";
 import DiaryKeywordImagesSlider from "../../components/diaryDetail/DiaryKeywordImagesSlider";
 import DiaryControlButton from "./DiaryControlButton";
+import { useIsMutating } from "@tanstack/react-query";
 
 export const DIARY_DETAIL_PAGE_PATH = "/diary/detail";
 
 const DiaryDetail = () => {
   let { diary, isDiaryExist } = useFetchDiary();
-  const content = diary?.data?.result?.[0]?.content;
+  const content = diary?.content;
 
   let { form, handleChangeInput } = useInput({
     content: content || "",
   });
+  const { selectedDate } = useCalendarStore((state) => state);
+
+  const isMutating = useIsMutating({ mutationKey: ["diary", selectedDate] });
 
   const [controlState, setControlState] = useState({
     isEditActive: !isDiaryExist,
     controlButtonActive: true,
     controlButtonText: `${!isDiaryExist ? "작성하기" : "수정하기"}`,
-    controlButtonMessage: "",
+    controlButtonMessage: isMutating ? "키워드 추출중입니다!" : " ",
   });
 
   return (

--- a/src/pages/diaryDetails/DiaryDetail.jsx
+++ b/src/pages/diaryDetails/DiaryDetail.jsx
@@ -11,7 +11,7 @@ import useUpdateDiary from "../../hooks/diaryDetail/queries/useUpdateDiary";
 export const DIARY_DETAIL_PAGE_PATH = "/diary/detail";
 
 const DiaryDetail = () => {
-  let { handleClick, controlState, content, handleChangeInput } =
+  let { handleClick, controlState, content, handleChangeInput, textAreaRef } =
     useDiaryControl();
 
   const create = useCreateDiary();
@@ -23,6 +23,7 @@ const DiaryDetail = () => {
       <DiaryDate />
       <DiaryKeywordImagesSlider />
       <TextareaAutosize
+        ref={textAreaRef}
         value={content}
         disabled={isMutating || !controlState.isEditActive}
         className={

--- a/src/pages/diaryDetails/DiaryDetail.jsx
+++ b/src/pages/diaryDetails/DiaryDetail.jsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
 import { dateToDotString } from "../../utils/api/dateConverter";
-import Slider from "react-slick";
 import { useCalendarStore } from "../../stores/CalendarStore";
 import useFetchDiary from "../../hooks/diary/queries/useFetchDiary";
 import { useInput } from "../../hooks/inputs/useInput";
 import TextareaAutosize from "react-textarea-autosize";
+import DiaryKeywordImagesSlider from "../../components/diaryDetail/DiaryKeywordImagesSlider";
+import DiaryControlButton from "./DiaryControlButton";
 
 export const DIARY_DETAIL_PAGE_PATH = "/diary/detail";
 
@@ -19,7 +20,7 @@ const DiaryDetail = () => {
   const [controlState, setControlState] = useState({
     isEditActive: !isDiaryExist,
     controlButtonActive: true,
-    controlButtonText: !isDiaryExist ? "작성하기" : "수정하기",
+    controlButtonText: `${!isDiaryExist ? "작성하기" : "수정하기"}`,
     controlButtonMessage: "",
   });
 
@@ -46,53 +47,6 @@ const DiaryDetail = () => {
   );
 };
 
-const settings = {
-  infinite: false,
-  arrows: false,
-  dots: true,
-  swipe: true,
-};
-
-const DiaryKeywordImagesSlider = () => {
-  let { isDiaryExist, diary } = useFetchDiary();
-
-  if (!isDiaryExist) {
-    return null;
-  }
-
-  const keywords = diary.data.result[0].keywords;
-
-  if (!keywords.some(({ imgUrl }) => imgUrl)) {
-    return <NoDiaryImage />;
-  }
-
-  return (
-    <Slider {...settings} className={"w-full rounded-xl overflow-clip"}>
-      {keywords.map(({ keywordId, imgUrl, keyword }, index) => (
-        <img
-          key={keywordId}
-          src={imgUrl}
-          alt={keyword}
-          className={`w-full bg-white aspect-square`}
-        />
-      ))}
-    </Slider>
-  );
-};
-
-const NoDiaryImage = () => {
-  return (
-    <div className={"mx-auto font-bold h-auto"}>
-      <span className={"text-2xl text-end tablet:text-4xl text-nowrap"}>
-        그려진 그림이 없어요.. <span className={"ml-4"}>😢</span>
-      </span>
-      <p className={"text-xl text-end mt-6 tablet:text-3xl cursor-pointer"}>
-        그림 그리러 가기 >
-      </p>
-    </div>
-  );
-};
-
 const DiaryDate = () => {
   const HorizontalLine = ({ className }) => {
     return <div className={`${className} border-2 border-[#5B5B5B]`}></div>;
@@ -108,61 +62,10 @@ const DiaryDate = () => {
   );
 };
 
-/**
- * @param content
- * @param className
- * @param controlState {ControlState}
- * @param setControlState
- * @param props
- * @return {Element}
- * @constructor
- */
-const DiaryControlButton = ({
-  content,
-  className,
-  controlState,
-  setControlState,
-  ...props
-}) => {
-  const handleClick = (e) => {
-    if (content === "") {
-      setControlState({
-        ...controlState,
-        message: "일기를 입력해주세요.",
-      });
-      return;
-    }
-
-    setControlState({
-      ...controlState,
-      isEditActive: false,
-      controlButtonActive: false,
-      controlButtonMessage: "",
-    });
-  };
-
-  return (
-    <>
-      <div className={"text-2xl text-red-600 text-center"}>
-        {controlState.controlButtonMessage}
-      </div>
-      <button
-        disabled={!controlState.controlButtonActive}
-        onClick={handleClick}
-        className={`border-2 bg-secondary-400 rounded-lg text-2xl py-3 ${className}`}
-        {...props}
-      >
-        {controlState.controlButtonText}
-      </button>
-    </>
-  );
-};
-
 export default DiaryDetail;
 
 /**
  * @typedef {{
- *   content: string,
  *   isEditActive: boolean,
  *   controlButtonActive: boolean,
  *   controlButtonText: string,


### PR DESCRIPTION
## PR type
- [x] Feature
- [x] Chore

## 💻 작업사항

- createDiary 메서드 구현, updateDiary 메서드 구현
  
- 일기 작성,수정 api 로직 구현
  <img width="300" src="https://github.com/user-attachments/assets/2ae389e4-98e1-4251-99c7-4920a3f008db" ><img width="300" src="https://github.com/user-attachments/assets/aa86df8b-d20f-4f20-89c1-18b3a31c3ed9" > 

## 💡 작성한 이슈 외에 작업한 사항

- AutoResize textarea 라이브러리 설치
- Spinner 재사용 가능하게 변경
- DiaryKeywordImagesSlider 새로고침에 오류 없게 수정

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
