### PR TITLE
Feat/78 최근 일기 목록 무한스크롤 Api 연동 

### DIFF
--- a/src/apis/diary.controller.js
+++ b/src/apis/diary.controller.js
@@ -85,6 +85,10 @@ class DiaryController extends Api {
     });
   };
 
+  recentDiaries = async ({ userId, page, pageSize }) => {
+    return await this.get(`/diary/user`, { userId, page, pageSize });
+  };
+
   // 일기 삭제
   // deleteDiary = async (diaryId, diaryData) => {
   //   return await this.delete(`/diary/${diaryId}`);

--- a/src/hooks/auth/query/useAutoLogin.js
+++ b/src/hooks/auth/query/useAutoLogin.js
@@ -6,6 +6,7 @@ import {
 } from "../../../utils/auth/localStorageController";
 import { useQuery } from "@tanstack/react-query";
 import userStore from "../../../stores/UserStore";
+import { HOUR, MINUTE } from "../../../utils/api/dateConverter";
 
 const useAutoLogin = () => {
   const preLocalStorageData = getUserInLocalStorage();
@@ -33,13 +34,13 @@ const useAutoLogin = () => {
       return response.data.result;
     },
     retry: 0,
-    staleTime: 0,
+    staleTime: 2 * HOUR,
     gcTime: 0,
   });
 
   const isAutoLoginSuccess = isSuccess && !isFetching;
 
-  return { isAutoLoginSuccess };
+  return { isAutoLoginSuccess, isFetching };
 };
 
 export default useAutoLogin;

--- a/src/hooks/auth/query/useAutoLogin.js
+++ b/src/hooks/auth/query/useAutoLogin.js
@@ -40,7 +40,7 @@ const useAutoLogin = () => {
 
   const isAutoLoginSuccess = isSuccess && !isFetching;
 
-  return { isAutoLoginSuccess, isFetching };
+  return { isAutoLoginSuccess, isLoggingIn: isFetching };
 };
 
 export default useAutoLogin;

--- a/src/hooks/auth/useRequireAuth.js
+++ b/src/hooks/auth/useRequireAuth.js
@@ -2,17 +2,26 @@ import useUserStore from "../../stores/UserStore";
 import { useNavigate } from "react-router-dom";
 import { SIGNIN_PAGE_PATH } from "../../pages/auths/Signin";
 import { useEffect } from "react";
+import useAutoLogin from "./query/useAutoLogin";
 
 const useRequireAuth = () => {
+  const { isAutoLoginSuccess, isLoggingIn } = useAutoLogin();
   const navigate = useNavigate();
   const { isLogin, userId } = useUserStore((state) => state);
   useEffect(() => {
-    if (!isLogin || userId === 0) {
+    if (isLoggingIn) return;
+
+    if (!isLogin || userId === 0 || !isAutoLoginSuccess) {
       navigate(SIGNIN_PAGE_PATH);
     }
-  }, [isLogin, userId]);
+  }, [isAutoLoginSuccess, isLoggingIn, isLogin, userId]);
 
-  return { userId: isLogin ? userId : 0, isLogin };
+  return {
+    userId: isLogin ? userId : 0,
+    isLogin,
+    isLoggingIn,
+    isAutoLoginSuccess,
+  };
 };
 
 export default useRequireAuth;

--- a/src/hooks/common/useScreenOn.js
+++ b/src/hooks/common/useScreenOn.js
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+//
+/**
+ * useScreenOn은 targetRef를 관찰하여 화면에 보이는지 여부를 반환하는 hook입니다.
+ * @param marginOffset - 관찰할 targetRef의 margin을 설정합니다 . (default: 0)
+ * @return {{targetRef: React.MutableRefObject<null>, isOnScreen: boolean}}
+ */
+const useScreenOn = ({ marginOffset = 0 }) => {
+  const targetRef = useRef(null);
+  const [isOnScreen, setIsOnScreen] = useState(false);
+
+  const handleOnScreen = useCallback(([entry]) => {
+    setIsOnScreen(entry.isIntersecting);
+  }, []);
+
+  const observer = useMemo(
+    () =>
+      new IntersectionObserver(handleOnScreen, {
+        rootMargin: `${marginOffset}px`,
+      }),
+    []
+  );
+
+  useEffect(() => {
+    if (!targetRef.current) return;
+
+    observer.observe(targetRef.current);
+
+    return () => observer.disconnect();
+  }, [targetRef]);
+
+  return { isOnScreen, targetRef };
+};
+
+export default useScreenOn;

--- a/src/hooks/diary/queries/useFetchRecentDiary.js
+++ b/src/hooks/diary/queries/useFetchRecentDiary.js
@@ -3,7 +3,7 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { MINUTE } from "../../../utils/api/dateConverter";
 import useScreenOn from "../../common/useScreenOn";
 import { useEffect } from "react";
-import { generateRecentMock } from "../../../utils/mock/diary/recent";
+import DiaryController from "../../../apis/diary.controller";
 
 const useFetchRecentDiary = () => {
   const { userId, isLogin } = useRequireAuth();
@@ -12,7 +12,11 @@ const useFetchRecentDiary = () => {
     useInfiniteQuery({
       queryKey: ["diary", "recent"],
       queryFn: async ({ pageParam }) => {
-        const response = await generateRecentMock(pageParam, 6);
+        const response = await DiaryController.recentDiaries({
+          userId,
+          page: pageParam,
+          pageSize: 10,
+        });
         return response.data.result;
       },
       initialPageParam: 1,

--- a/src/hooks/diary/queries/useFetchRecentDiary.js
+++ b/src/hooks/diary/queries/useFetchRecentDiary.js
@@ -1,0 +1,40 @@
+import useRequireAuth from "../../auth/useRequireAuth";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { MINUTE } from "../../../utils/api/dateConverter";
+import useScreenOn from "../../common/useScreenOn";
+import { useEffect } from "react";
+import { generateRecentMock } from "../../../utils/mock/diary/recent";
+
+const useFetchRecentDiary = () => {
+  const { userId, isLogin } = useRequireAuth();
+
+  let { data, isFetching, fetchNextPage, isSuccess, hasNextPage } =
+    useInfiniteQuery({
+      queryKey: ["diary", "recent"],
+      queryFn: async ({ pageParam }) => {
+        const response = await generateRecentMock(pageParam, 6);
+        return response.data.result;
+      },
+      initialPageParam: 1,
+      getNextPageParam: (lastPage, allPages, lastPageParam) => {
+        if (lastPage.hasNext) return lastPageParam + 1;
+        return undefined;
+      },
+      enabled: isLogin,
+      staleTime: MINUTE,
+      gcTime: 5 * MINUTE,
+    });
+
+  const { isOnScreen, targetRef } = useScreenOn({
+    marginOffset: 100,
+  });
+
+  useEffect(() => {
+    if (!isOnScreen || isFetching || !hasNextPage) return;
+    fetchNextPage();
+  }, [isOnScreen, isFetching, isSuccess]);
+
+  return { data, isFetching, isSuccess, targetRef };
+};
+
+export default useFetchRecentDiary;

--- a/src/pages/mypage/MyPage.jsx
+++ b/src/pages/mypage/MyPage.jsx
@@ -9,12 +9,14 @@ import userStore from "../../stores/UserStore";
 import { useQueryClient } from "@tanstack/react-query";
 import RecentDiagnosisGraph from "../../components/mypage/RecentDiagnosisGraph";
 import useFetchRecentDiagnosis from "../../hooks/Diagnosis/queries/useFetchRecentDiagnosis";
+import { RECENT_DIARIES_PAGE_PATH } from "./RecentDiaries";
 
 export const MY_PAGE_PATH = "/mypage";
 
 const MyPage = () => {
   const { user } = useFetchUser();
   const { record, isCanRender } = useFetchRecentDiagnosis();
+  const navigate = useNavigate();
 
   const [isOpen, setIsOpen] = useState({
     fontSize: false,
@@ -28,6 +30,10 @@ const MyPage = () => {
     });
   };
 
+  const goRecentDiaryPage = () => {
+    navigate(RECENT_DIARIES_PAGE_PATH);
+  };
+
   return (
     <div className={"relative pb-20 flex flex-col gap-4 px-4"}>
       <h1 className={"text-5xl font-bold"}>{user?.username}</h1>
@@ -39,7 +45,9 @@ const MyPage = () => {
 
       <p className={"border-b-2 border-black my-6"} />
 
-      <h1 className={"text-3xl"}>최근 일기</h1>
+      <h1 onClick={goRecentDiaryPage} className={"text-3xl cursor-pointer"}>
+        최근 일기
+      </h1>
       <FontSizeControl
         isOpen={isOpen.fontSize}
         onClick={() => onClick("fontSize")}

--- a/src/pages/mypage/RecentDiaries.js
+++ b/src/pages/mypage/RecentDiaries.js
@@ -3,10 +3,8 @@ import { range } from "../../utils/array/range";
 import { ResponseSkeleton } from "../../components/skeleton/ResponseSkeleton";
 import useFetchRecentDiary from "../../hooks/diary/queries/useFetchRecentDiary";
 import { useCalendarStore } from "../../stores/CalendarStore";
-import useNavBar from "../../hooks/navbar/useNavBar";
 import { useNavigate } from "react-router-dom";
 import { DIARY_PAGE_PATH } from "../diarys/Diary";
-import { DIARY_DETAIL_PAGE_PATH } from "../diaryDetails/DiaryDetail";
 
 export const RECENT_DIARIES_PAGE_PATH = "/recentdiaries";
 
@@ -69,7 +67,7 @@ const DiaryItem = ({ diary }) => {
   const onClick = () => {
     setSelectedYearMonth({ year, month });
     setSelectedDate({ year, month, day });
-    navigate(DIARY_DETAIL_PAGE_PATH);
+    navigate(DIARY_PAGE_PATH);
   };
 
   return (

--- a/src/pages/mypage/RecentDiaries.js
+++ b/src/pages/mypage/RecentDiaries.js
@@ -1,42 +1,12 @@
-import React, { useEffect } from "react";
-import useRequireAuth from "../../hooks/auth/useRequireAuth";
-import { useInfiniteQuery } from "@tanstack/react-query";
-import { generateRecentMock } from "../../utils/mock/diary/diaryMockData";
-import { MINUTE } from "../../utils/api/dateConverter";
-import useScreenOn from "../../hooks/common/useScreenOn";
+import React from "react";
 import { range } from "../../utils/array/range";
 import { ResponseSkeleton } from "../../components/skeleton/ResponseSkeleton";
+import useFetchRecentDiary from "../../hooks/diary/queries/useFetchRecentDiary";
 
 export const RECENT_DIARIES_PAGE_PATH = "/recentdiaries";
 
 const RecentDiaries = () => {
-  const { userId, isLogin } = useRequireAuth();
-
-  let { data, isFetching, fetchNextPage, isSuccess, hasNextPage } =
-    useInfiniteQuery({
-      queryKey: ["diary", "recent"],
-      queryFn: async ({ pageParam }) => {
-        const response = await generateRecentMock(pageParam, 6);
-        return response.data.result;
-      },
-      initialPageParam: 1,
-      getNextPageParam: (lastPage, allPages, lastPageParam) => {
-        if (lastPage.hasNext) return lastPageParam + 1;
-        return undefined;
-      },
-      enabled: isLogin,
-      staleTime: MINUTE,
-      gcTime: 5 * MINUTE,
-    });
-
-  const { isOnScreen, targetRef } = useScreenOn({
-    marginOffset: 30,
-  });
-
-  useEffect(() => {
-    if (!isOnScreen || isFetching || !hasNextPage) return;
-    fetchNextPage();
-  }, [isOnScreen, isFetching, isSuccess]);
+  const { data, isFetching, isSuccess, targetRef } = useFetchRecentDiary();
 
   return (
     <div className="ml-10 md:ml-20 pb-6">

--- a/src/pages/mypage/RecentDiaries.js
+++ b/src/pages/mypage/RecentDiaries.js
@@ -1,73 +1,71 @@
-import React from "react";
+import React, { useEffect } from "react";
+import useRequireAuth from "../../hooks/auth/useRequireAuth";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { generateRecentMock } from "../../utils/mock/diary/diaryMockData";
+import { MINUTE } from "../../utils/api/dateConverter";
+import useScreenOn from "../../hooks/common/useScreenOn";
+import { range } from "../../utils/array/range";
+import { ResponseSkeleton } from "../../components/skeleton/ResponseSkeleton";
 
 export const RECENT_DIARIES_PAGE_PATH = "/recentdiaries";
 
 const RecentDiaries = () => {
-  const MonthlyDiaryData = [
-    {
-      year: 2024,
-      months: [
-        {
-          month: 7,
-          records: [
-            { date: "2024-07-17" },
-            { date: "2024-07-09" },
-            { date: "2024-07-02" },
-          ],
-        },
-        {
-          month: 6,
-          records: [
-            { date: "2024-06-24" },
-            { date: "2024-06-18" },
-            { date: "2024-06-15" },
-          ],
-        },
-      ],
-    },
-    {
-      year: 2023,
-      months: [
-        {
-          month: 12,
-          records: [
-            { date: "2023-12-16" },
-            { date: "2023-12-08" },
-            { date: "2023-12-04" },
-          ],
-        },
-      ],
-    },
-  ];
+  const { userId, isLogin } = useRequireAuth();
+
+  let { data, isFetching, fetchNextPage, isSuccess, hasNextPage } =
+    useInfiniteQuery({
+      queryKey: ["diary", "recent"],
+      queryFn: async ({ pageParam }) => {
+        const response = await generateRecentMock(pageParam, 6);
+        return response.data.result;
+      },
+      initialPageParam: 1,
+      getNextPageParam: (lastPage, allPages, lastPageParam) => {
+        if (lastPage.hasNext) return lastPageParam + 1;
+        return undefined;
+      },
+      enabled: isLogin,
+      staleTime: MINUTE,
+      gcTime: 5 * MINUTE,
+    });
+
+  const { isOnScreen, targetRef } = useScreenOn({
+    marginOffset: 30,
+  });
+
+  useEffect(() => {
+    if (!isOnScreen || isFetching || !hasNextPage) return;
+    fetchNextPage();
+  }, [isOnScreen, isFetching, isSuccess]);
 
   return (
-    <div>
-      <MonthlyDiaryList data={MonthlyDiaryData} />
+    <div className="ml-10 md:ml-20 pb-6">
+      {isSuccess &&
+        Object.entries(convertData(data)).map(([yearMonth, diaryArr]) => {
+          const [year, month] = yearMonth.split("-");
+          return (
+            <div key={yearMonth} className="my-8 md:my-16">
+              <MonthlyTitle year={year} month={month} />
+              {diaryArr.map((diary) => (
+                <DiaryItem key={diary.diaryId} diary={diary} />
+              ))}
+            </div>
+          );
+        })}
+      <div className={"flex flex-col gap-8"}>
+        {isFetching &&
+          range(6).map(() => (
+            <div className={"h-12 overflow-clip rounded-lg-xl"}>
+              <ResponseSkeleton />
+            </div>
+          ))}
+      </div>
+      <div ref={targetRef} />
     </div>
   );
 };
 
 export default RecentDiaries;
-
-const MonthlyDiaryList = ({ data }) => {
-  return (
-    <div className="ml-10 md:ml-20 pb-6">
-      {data.map((yearData) =>
-        yearData.months.map((monthData) => (
-          <div
-            key={`${yearData.year}-${monthData.month}`}
-            className="my-8 md:my-16"
-          >
-            <MonthlyTitle year={yearData.year} month={monthData.month} />
-            {monthData.records.map((record, index) => (
-              <DiaryItem key={index} date={record.date} />
-            ))}
-          </div>
-        ))
-      )}
-    </div>
-  );
-};
 
 const MonthlyTitle = ({ year, month }) => {
   return (
@@ -80,18 +78,23 @@ const MonthlyTitle = ({ year, month }) => {
   );
 };
 
-const DiaryItem = ({ date }) => {
+const DiaryItem = ({ diary }) => {
+  const { createDate } = diary;
+  const [year, month, day] = createDate.split("-");
   return (
     <div className="text-xl md:text-3xl my-9 flex justify-between pr-5">
-      {formatDate(date)}
+      {`${Number(month)}월 ${Number(day)}일의 일기`}
       <button>확인하기 {">"} </button>
     </div>
   );
 };
 
-const formatDate = (dateString) => {
-  const date = new Date(dateString);
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  return `${month}월 ${day}일의 일기`;
+const convertData = (data) => {
+  return Object.groupBy(
+    data.pages
+      .flat()
+      .map((response) => response.diaryList)
+      .flat(),
+    ({ createDate }) => createDate.slice(0, 7)
+  );
 };

--- a/src/pages/mypage/RecentDiaries.js
+++ b/src/pages/mypage/RecentDiaries.js
@@ -25,7 +25,10 @@ const RecentDiaries = () => {
       <div className={"flex flex-col gap-8"}>
         {isFetching &&
           range(6).map(() => (
-            <div className={"h-12 overflow-clip rounded-lg-xl"}>
+            <div
+              key={Math.random()}
+              className={"h-12 overflow-clip rounded-lg-xl"}
+            >
               <ResponseSkeleton />
             </div>
           ))}
@@ -59,11 +62,17 @@ const DiaryItem = ({ diary }) => {
   );
 };
 
+/**
+ * { pages: [[ {diaryId : 0, createDate: "", diaryList: [...], ...}, ... ]]}
+ * 위 데이터를
+ * { "2022-02": [{diaryId : 0, createDate: "", diaryList: [...], ...}, ...], "2022-01": [{diaryId : 0, createDate: "", diaryList: [...], ...}, ...] }
+ * 형태로 변환
+ */
 const convertData = (data) => {
   return Object.groupBy(
     data.pages
       .flat()
-      .map((response) => response.diaryList)
+      .map(({ diaryList }) => diaryList)
       .flat(),
     ({ createDate }) => createDate.slice(0, 7)
   );

--- a/src/pages/mypage/RecentDiaries.js
+++ b/src/pages/mypage/RecentDiaries.js
@@ -2,6 +2,11 @@ import React from "react";
 import { range } from "../../utils/array/range";
 import { ResponseSkeleton } from "../../components/skeleton/ResponseSkeleton";
 import useFetchRecentDiary from "../../hooks/diary/queries/useFetchRecentDiary";
+import { useCalendarStore } from "../../stores/CalendarStore";
+import useNavBar from "../../hooks/navbar/useNavBar";
+import { useNavigate } from "react-router-dom";
+import { DIARY_PAGE_PATH } from "../diarys/Diary";
+import { DIARY_DETAIL_PAGE_PATH } from "../diaryDetails/DiaryDetail";
 
 export const RECENT_DIARIES_PAGE_PATH = "/recentdiaries";
 
@@ -52,12 +57,25 @@ const MonthlyTitle = ({ year, month }) => {
 };
 
 const DiaryItem = ({ diary }) => {
+  const { setSelectedYearMonth, setSelectedDate } = useCalendarStore(
+    (state) => state
+  );
+
+  const navigate = useNavigate();
+
   const { createDate } = diary;
-  const [year, month, day] = createDate.split("-");
+  const [year, month, day] = createDate.split("-").map((i) => Number(i));
+
+  const onClick = () => {
+    setSelectedYearMonth({ year, month });
+    setSelectedDate({ year, month, day });
+    navigate(DIARY_DETAIL_PAGE_PATH);
+  };
+
   return (
     <div className="text-xl md:text-3xl my-9 flex justify-between pr-5">
       {`${Number(month)}월 ${Number(day)}일의 일기`}
-      <button>확인하기 {">"} </button>
+      <button onClick={onClick}>확인하기 {">"} </button>
     </div>
   );
 };

--- a/src/utils/mock/diary/recent.js
+++ b/src/utils/mock/diary/recent.js
@@ -1,0 +1,33 @@
+import { range } from "../../array/range";
+import { delay } from "../../api/delay";
+
+const recentDiary = range(10)
+  .map((value1) =>
+    range(20).map((value2) => ({
+      diaryId: value1 * 5 + value2,
+      title: `title${value1 * 5 + value2}`,
+      content: `content${value1 * 5 + value2}`,
+      createDate: `2024-${String(value1 + 1).padStart(2, "0")}-${String(value2 + 1).padStart(2, "0")}`,
+      imgUrl: "https://source.unsplash.com/random",
+    }))
+  )
+  .flat()
+  .reverse();
+
+export const generateRecentMock = async (page, pageSize) => {
+  const pageObj = () => {
+    const diaryList = recentDiary.slice((page - 1) * pageSize, page * pageSize);
+    return {
+      totalDataSize: recentDiary.length,
+      totalPage: Math.ceil(recentDiary.length / pageSize),
+      hasNext: diaryList.at(-1).diaryId !== recentDiary.at(-1).diaryId,
+      hasPrevious: diaryList.at(0).diaryId !== recentDiary.at(0).diaryId,
+      currentPage: page,
+      dataSize: diaryList.length,
+      diaryList,
+    };
+  };
+
+  await delay(600);
+  return { data: { result: pageObj(page, pageSize) } };
+};


### PR DESCRIPTION
## PR type
- [x] Feature

## 💻 작업사항

- 화면에 노출이 되는지 판단할 useScreenOn.js 훅 구현
- 최근 일기 목록 무한스크롤 Api 연동 
<img width="300" src="https://github.com/user-attachments/assets/0253cf34-a7a3-453c-8ec4-bc53f57697ec">
<img width="300" src="https://github.com/user-attachments/assets/186f44fc-ad15-446d-a203-f46416f244d7">



## 💡 작성한 이슈 외에 작업한 사항

- 자동 로그인 2시간 지속으로 변경
- useRequireAuth.js, useAutoLogin.js 로그인 상태 같이 추척하게 변경
- 일기 무한 스크롤을 위한 모킹 데이터 구현

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
