### PR TITLE
Refactor/162 일기 쓰러 가기 버튼 수정 및 마이페이지 폰트 크기 수정

### DIFF
--- a/src/components/calendar/NoDiary.jsx
+++ b/src/components/calendar/NoDiary.jsx
@@ -10,7 +10,7 @@ const NoDiary = ({ isExist }) => {
   return (
     <div
       className={
-        "px-4 flex font-bold flex-col gap-4 mt-4 text-2xl tablet:text-4xl tablet:gap-10 tablet:mt-10"
+        "px-4 flex font-bold flex-col mobile:gap-4 mobile:mt-4 mobile:text-2xl text-4xl gap-10 mt-10"
       }
     >
       <div>직접 쓴 일기로 그림을 그리고</div>
@@ -28,11 +28,11 @@ const GoWriteDiaryButton = () => {
         navigate(DIARY_DETAIL_PAGE_PATH);
       }}
       className={
-        "flex items-center border-2 rounded-xl h-40 p-4 bg-secondary-600 tablet:h-64 cursor-pointer"
+        "flex items-center border-2 rounded-xl mobile:h-28 p-4 bg-secondary-600 h-48 cursor-pointer mb-5"
       }
     >
-      <img src={btn_diary} className={"h-full"} />
-      <div className={"text-3xl text-[#5B5B5B] tablet:text-5xl"}>
+      <img src={btn_diary} className={"h-full mr-5"} />
+      <div className={"mobile:text-2xl text-[#5B5B5B] text-4xl"}>
         일기 쓰러 가기
       </div>
     </div>

--- a/src/components/mypage/FontSizeControl.jsx
+++ b/src/components/mypage/FontSizeControl.jsx
@@ -7,31 +7,28 @@ import useFontSizeStore from "../../stores/FontSizeStore";
 const FontSizeControl = ({ isOpen, onClick = () => {} }) => {
   const BUTTONS = [
     { title: "작게", size: "12px" },
-    { title: "중간", size: "14px" },
+    { title: "중간", size: "16px" },
     { title: "크게", size: "18px" },
   ];
 
-  // 기본 선택 중인 폰트 크기 설정 (중간)
-  const [selectedFontButton, setSelectedFontButton] = useState(BUTTONS[1]);
-  const setFontSize = useFontSizeStore((state) => state.setFontSize);
+  const { setFontSize, fontSize } = useFontSizeStore((state) => state);
 
-  const onClickButton = ({ title, size }) => {
-    setSelectedFontButton({ title, size });
+  const onClickButton = (size) => {
     setFontSize(size);
   };
 
   return (
     <>
       <MyPageItem title={"글씨 크기 조절"} isOpen={isOpen} onClick={onClick} />
-      <AccordionWrapper isOpen={isOpen}>
-        <div className={"flex justify-between gap-3"}>
+      <AccordionWrapper key={fontSize} isOpen={isOpen}>
+        <div className={"flex justify-between gap-3 "}>
           {BUTTONS.map((button) => (
             <Button
               key={button.title}
               className={`p-2 max-w-40 w-full text-nowrap cursor-pointer
-              ${button.size === selectedFontButton.size ? "bg-[#6100C1] text-white" : "border-[#6100C1] text-black"}`}
+              ${button.size === fontSize ? "bg-[#6100C1] text-white" : "border-[#6100C1] text-black"}`}
               text={button.title}
-              onClick={() => onClickButton(button)}
+              onClick={() => onClickButton(button.size)}
             />
           ))}
         </div>

--- a/src/hooks/auth/useRequireAuth.js
+++ b/src/hooks/auth/useRequireAuth.js
@@ -9,10 +9,10 @@ const useRequireAuth = () => {
   const navigate = useNavigate();
   const { isLogin, userId } = useUserStore((state) => state);
   useEffect(() => {
-    if (isLoggingIn) return;
+    if (isLoggingIn || window.location.pathname === SIGNIN_PAGE_PATH) return;
 
     if (!isLogin || userId === 0 || !isAutoLoginSuccess) {
-      navigate(SIGNIN_PAGE_PATH);
+      navigate(SIGNIN_PAGE_PATH, { replace: true });
     }
   }, [isAutoLoginSuccess, isLoggingIn, isLogin, userId]);
 

--- a/src/stores/FontSizeStore.js
+++ b/src/stores/FontSizeStore.js
@@ -1,8 +1,11 @@
 import create from "zustand";
 
 const useFontSizeStore = create((set) => ({
-  fontSize: "16px",
-  setFontSize: (size) => set({ fontSize: size }),
+  fontSize: localStorage.getItem("fontSize") || "16px",
+  setFontSize: (size) => {
+    localStorage.setItem("fontSize", size);
+    set({ fontSize: size });
+  },
 }));
 
 export default useFontSizeStore;


### PR DESCRIPTION
## PR type
- [x] Refactor

## 💻 작업사항

- 일기 쓰러 가기 버튼 밑에 마진 주기
- 크기 좀 줄이기
- 마이페이지 폰트 수정 시 잘리는 오류 해결

## 💡 작성한 이슈 외에 작업한 사항

- 로그인 페이지에서 뒤로 가기 클릭 시 작동하도록 수정
- 폰트 크기 localStoarge에 저장

## Images
### 일기 쓰러 가기 버튼 수정
<img width="300" alt="image" src="https://github.com/user-attachments/assets/8d566b00-986a-425c-8fe2-84d41fd8f271">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/8345b557-ae67-4ff9-a207-8f9c9944df2c">

### 마이페이지 폰트 수정
<img width="300" src="https://github.com/user-attachments/assets/032fd0ed-d1a8-4bf9-902e-eca1bc5af526">


## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
